### PR TITLE
WASM deps fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.11.0"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
+checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
 
 [[package]]
 name = "byteorder"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.10.0"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
+checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
 
 [[package]]
 name = "byteorder"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,11 +435,11 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.28"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
+checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -703,13 +703,13 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.75"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f58f7e8eaa0009c5fec437aabf511bd9933e4b2d7407bd05273c01a8906ea7"
+checksum = "3fcd952facd492f9be3ef0d0b7032a6e442ee9b361d4acc2b1d0c4aaa5f613a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -741,16 +741,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-ident"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,7 +698,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff63080f492dd4d289ffcaed8d7ece38adfb423db910eb342c0e04d409536a7a"
 dependencies = [
  "paste",
- "serde_str_helpers 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ amplify_derive = { version = "2.10.0", path = "./derive", optional = true }
 amplify_syn = { version = "1.1", path = "./syn", optional = true }
 amplify_num = { version = "0.4.0", path = "./num" }
 amplify_apfloat = { version = "0.1.1", path = "./apfloat", optional = true }
-parse_arg = { version = "0.1.4", optional = true }
 rand = { version = "0.8.4", optional = true }
 # This strange naming is a workaround for not being able to define required features for a dependency
 # See https://github.com/rust-lang/api-guidelines/issues/180 for the explanation and references.
@@ -51,6 +50,9 @@ stringly_conversions = { version = "0.1.1", optional = true, features = [
 criterion = "0.2.11"
 softposit = "0.3.9"
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+parse_arg = { version = "0.1.4", optional = true }
+
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"
 rand = { version = "0.8.4", optional = true }
@@ -59,7 +61,7 @@ getrandom = { version = "0.2", features = ["js"], optional = true }
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3"
 
-[features]
+[target.'cfg(not(target_arch = "wasm32"))'.features]
 all = [
     "serde",
     "std",
@@ -108,7 +110,6 @@ serde = [
 all = [
     "serde",
     "std",
-    "parse_arg",
     "stringly_conversions",
     "c_raw",
     "proc_attr",
@@ -122,7 +123,6 @@ default = ["std", "derive", "hex"]
 compat = [
     "serde",
     "std",
-    "parse_arg",
     "stringly_conversions",
     "c_raw",
     "proc_attr",


### PR DESCRIPTION
I looked into the problem mentioned here:
https://github.com/rust-amplify/rust-amplify/issues/143#issuecomment-1271854869

After some digging and experimentation it turns out syn is still on edition 2018, and later versions are compatible with wasm.

I also pegged bumpalo to pre-2018 because of this issue in CI:
https://github.com/rust-amplify/rust-amplify/actions/runs/3204197605/jobs/5235207716#step:7:44