### PR TITLE
Improve performance of unsigned integers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,37 +102,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "bstr"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
-dependencies = [
- "lazy_static",
- "memchr",
- "regex-automata",
- "serde",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
 
 [[package]]
-name = "byteorder"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
-
-[[package]]
 name = "cast"
-version = "0.2.7"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
-dependencies = [
- "rustc_version",
-]
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cfg-if"
@@ -135,23 +120,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "clap"
-version = "2.34.0"
+name = "ciborium"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
 dependencies = [
- "bitflags",
- "textwrap",
- "unicode-width",
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
 ]
 
 [[package]]
-name = "cloudabi"
-version = "0.0.3"
+name = "ciborium-io"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "3.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
 dependencies = [
  "bitflags",
+ "clap_lex",
+ "indexmap",
+ "textwrap",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -166,24 +179,23 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.2.11"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0363053954f3e679645fc443321ca128b7b950a6fe288cf5f9335cc22ee58394"
+checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
 dependencies = [
+ "anes",
  "atty",
  "cast",
+ "ciborium",
  "clap",
  "criterion-plot",
- "csv",
  "itertools",
  "lazy_static",
- "libc",
  "num-traits",
- "rand_core 0.3.1",
- "rand_os",
- "rand_xoshiro",
+ "oorandom",
+ "plotters",
  "rayon",
- "rayon-core",
+ "regex",
  "serde",
  "serde_derive",
  "serde_json",
@@ -193,11 +205,10 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.3.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f9212ddf2f4a9eb2d401635190600656a1f88a932ef53d06e7fa4c7e02fb8e"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
- "byteorder",
  "cast",
  "itertools",
 ]
@@ -247,28 +258,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "csv"
-version = "1.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
-dependencies = [
- "bstr",
- "csv-core",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "dtoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,12 +268,6 @@ name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "getrandom"
@@ -298,6 +281,12 @@ dependencies = [
  "wasi",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hashbrown"
@@ -326,9 +315,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.8.2"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
@@ -376,12 +365,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memchr"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
-
-[[package]]
 name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -416,6 +399,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
 
 [[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+
+[[package]]
 name = "parse_arg"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -426,6 +421,34 @@ name = "paste"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
+
+[[package]]
+name = "plotters"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2538b639e642295546c50fcd545198c9d64ee2a38620a628724a3b266d5fbf97"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "193228616381fecdc1224c62e96946dfbc73ff4384fba576e052ff8c1bea8142"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a81d2759aae1dae668f783c308bc5c8ebd191ff4184aaa1b37f65a6ae5a56f"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -459,7 +482,7 @@ checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.3",
+ "rand_core",
  "rand_hc",
 ]
 
@@ -470,23 +493,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.3",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -503,31 +511,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
- "rand_core 0.6.3",
-]
-
-[[package]]
-name = "rand_os"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
-dependencies = [
- "cloudabi",
- "fuchsia-cprng",
- "libc",
- "rand_core 0.4.2",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand_xoshiro"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b418169fb9c46533f326efd6eed2576699c44ca92d3052a066214a8d828929"
-dependencies = [
- "byteorder",
- "rand_core 0.3.1",
+ "rand_core",
 ]
 
 [[package]]
@@ -556,28 +540,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "rdrand"
-version = "0.4.0"
+name = "regex"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
- "rand_core 0.3.1",
+ "regex-syntax",
 ]
 
 [[package]]
-name = "regex-automata"
-version = "0.1.10"
+name = "regex-syntax"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-
-[[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver",
-]
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "ryu"
@@ -605,12 +580,6 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "semver"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d"
 
 [[package]]
 name = "serde"
@@ -714,12 +683,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "tinytemplate"
@@ -739,12 +705,6 @@ checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,9 @@ exclude = [
 [lib]
 name = "amplify"
 path = "src/lib.rs"
+# Allow --save-baseline to work
+# https://github.com/bheisler/criterion.rs/issues/275
+bench = false
 
 [dependencies]
 libc = { version = "0.2", optional = true }
@@ -48,7 +51,7 @@ stringly_conversions = { version = "0.1.1", optional = true, features = [
 
 # avoid building criterion in 1.41.1 CI
 [target.'cfg(bench)'.dev-dependencies]
-criterion = "0.2.11"
+criterion = "0.4"
 softposit = "0.3.9"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -3,7 +3,7 @@ extern crate criterion;
 
 use criterion::{black_box, Criterion};
 
-use amplify_num::u1024;
+use amplify_num::{i1024, u1024};
 use amplify_num::posit::Posit32;
 use softposit::P32;
 
@@ -28,6 +28,52 @@ fn criterion_u1024(c: &mut Criterion) {
     });
     c.bench_function("u1024_div", |c| {
         c.iter(|| black_box(X).overflowing_div(black_box(Y)))
+    });
+    c.bench_function("u1024_cmp_eq", |c| {
+        c.iter(|| black_box(X).cmp(black_box(&X)))
+    });
+}
+
+fn criterion_i1024(c: &mut Criterion) {
+    const X: i1024 = i1024::from_inner([
+        0xe4, 0xf7, 0xab, 0x7f, 0xdd, 0xaa, 0xbb, 0xcc, 0x77, 0x66, 0xf5, 0x06, 0x39, 0xa2, 0xb8,
+        0xcc,
+    ]);
+    const Y: i1024 = i1024::from_inner([
+        0xd2, 0x77, 0x66, 0xf5, 0x06, 0x39, 0xee, 0xa6, 0xf7, 0xab, 0x7f, 0xc2, 0x55, 0x75, 0x90,
+        0x21,
+    ]);
+    const Z: i1024 = i1024::from_inner([
+        0xd2, 0x77, 0x66, 0xf5, 0x06, 0x39, 0xee, 0xa6, 0xf7, 0xab, 0x7f, 0xc2, 0x55, 0x75, 0x90,
+        0xffff_ffff_ffff_ff21,
+    ]);
+    assert!(X.is_positive());
+    assert!(Y.is_positive());
+    assert!(Z.is_negative());
+
+    c.bench_function("i1024_add", |c| {
+        c.iter(|| black_box(X).overflowing_add(black_box(Y)))
+    });
+    c.bench_function("i1024_is_positive", |c| {
+        c.iter(|| black_box(X).is_positive())
+    });
+    c.bench_function("i1024_is_negative", |c| {
+        c.iter(|| black_box(X).is_negative())
+    });
+    c.bench_function("i1024_zero_is_positive", |c| {
+        c.iter(|| black_box(i1024::ZERO).is_positive())
+    });
+    c.bench_function("i1024_zero_is_negative", |c| {
+        c.iter(|| black_box(i1024::ZERO).is_positive())
+    });
+    c.bench_function("i1024_cmp_pos", |c| {
+        c.iter(|| black_box(X).cmp(black_box(&X)))
+    });
+    c.bench_function("i1024_cmp_mixed", |c| {
+        c.iter(|| black_box(X).cmp(black_box(&Z)))
+    });
+    c.bench_function("i1024_cmp_eq", |c| {
+        c.iter(|| black_box(X).cmp(black_box(&X)))
     });
 }
 
@@ -69,6 +115,7 @@ fn criterion_softposit32(c: &mut Criterion) {
 
 criterion_group!(
     benches,
+    criterion_i1024,
     criterion_u1024,
     criterion_posit32,
     criterion_softposit32

--- a/num/src/bigint.rs
+++ b/num/src/bigint.rs
@@ -160,6 +160,11 @@ macro_rules! construct_bigint {
             }
 
             #[inline]
+            pub fn is_positive(&self) -> bool {
+                !self.is_negative() && !self.is_zero()
+            }
+
+            #[inline]
             pub fn abs(self) -> $name {
                 if !self.is_negative() {
                     return self;
@@ -1453,14 +1458,8 @@ macro_rules! construct_signed_bigint_methods {
             };
 
             #[inline]
-            pub fn is_positive(&self) -> bool {
-                !self.is_zero()
-                    && self[($name::INNER_LEN - 1) as usize] & 0x8000_0000_0000_0000 == 0
-            }
-
-            #[inline]
             pub fn is_negative(&self) -> bool {
-                !self.is_zero() && !self.is_positive()
+                self[($name::INNER_LEN - 1) as usize] & 0x8000_0000_0000_0000 != 0
             }
 
             /// Return the least number of bits needed to represent the number
@@ -1525,11 +1524,6 @@ macro_rules! construct_unsigned_bigint_methods {
 
             /// Maximum value
             pub const MAX: $name = $name([::core::u64::MAX; $n_words]);
-
-            #[inline]
-            pub fn is_positive(&self) -> bool {
-                !self.is_zero()
-            }
 
             #[inline]
             pub fn is_negative(&self) -> bool {

--- a/num/src/bigint.rs
+++ b/num/src/bigint.rs
@@ -518,7 +518,7 @@ macro_rules! construct_bigint {
                     ret[i] = res;
                 }
                 let ret = Self(ret);
-                let overflow = if Self::MIN == Self::ZERO {
+                let overflow = if !Self::IS_SIGNED_TYPE {
                     carry > 0
                 } else {
                     self != Self::MIN
@@ -576,7 +576,7 @@ macro_rules! construct_bigint {
                 T: Into<$name>,
             {
                 let other = other.into();
-                if Self::MIN == Self::ZERO {
+                if !Self::IS_SIGNED_TYPE {
                     (
                         self.wrapping_add(!other).wrapping_add($name::ONE),
                         self < other,
@@ -1436,6 +1436,8 @@ macro_rules! construct_signed_bigint_methods {
         }
 
         impl $name {
+            const IS_SIGNED_TYPE: bool = true;
+
             /// Minimum value
             pub const MIN: $name = {
                 let mut min = [0u64; $n_words];
@@ -1516,6 +1518,8 @@ macro_rules! construct_signed_bigint_methods {
 macro_rules! construct_unsigned_bigint_methods {
     ( $ name: ident, $ n_words: expr ) => {
         impl $name {
+            const IS_SIGNED_TYPE: bool = false;
+
             /// Minimum value
             pub const MIN: $name = $name([0u64; $n_words]);
 


### PR DESCRIPTION
benchmark comparison with 'critcmp':

```
group                     patched                                master
-----                     -------                                ------
i1024_add                 1.00     46.5±2.35ns        ? ?/sec    1.20     55.6±3.58ns        ? ?/sec
i1024_cmp_eq              1.00     15.8±0.91ns        ? ?/sec    1.40     22.3±1.16ns        ? ?/sec
i1024_cmp_mixed           1.00     10.1±0.38ns        ? ?/sec    1.73     17.5±0.66ns        ? ?/sec
i1024_cmp_pos             1.00     15.8±0.88ns        ? ?/sec    1.41     22.3±0.91ns        ? ?/sec
i1024_is_negative         1.00      3.5±0.12ns        ? ?/sec    4.68     16.2±0.56ns        ? ?/sec
i1024_is_positive         1.00     15.8±0.84ns        ? ?/sec    1.03     16.3±0.84ns        ? ?/sec
i1024_zero_is_negative    1.00     16.4±0.61ns        ? ?/sec    1.02     16.8±0.61ns        ? ?/sec
i1024_zero_is_positive    1.00     16.6±1.02ns        ? ?/sec    1.02     16.9±0.83ns        ? ?/sec
posit32_add               1.00     32.2±3.37ns        ? ?/sec    1.00     32.2±1.80ns        ? ?/sec
posit32_div               1.00     49.0±1.75ns        ? ?/sec    1.01     49.6±2.37ns        ? ?/sec
posit32_mul               1.00     26.2±1.42ns        ? ?/sec    1.00     26.3±1.11ns        ? ?/sec
posit32_sub               1.02     34.3±3.57ns        ? ?/sec    1.00     33.5±1.83ns        ? ?/sec
softposit32_add           1.04      9.9±0.38ns        ? ?/sec    1.00      9.5±0.39ns        ? ?/sec
softposit32_div           1.00     22.6±0.85ns        ? ?/sec    1.01     22.8±0.82ns        ? ?/sec
softposit32_mul           1.00      8.6±0.35ns        ? ?/sec    1.27     10.9±0.50ns        ? ?/sec
softposit32_sub           1.05     12.3±0.56ns        ? ?/sec    1.00     11.6±0.51ns        ? ?/sec
u1024_add                 1.00     32.1±1.93ns        ? ?/sec    1.00     32.0±1.04ns        ? ?/sec
u1024_cmp_eq              1.00      8.2±0.48ns        ? ?/sec    1.24     10.2±0.38ns        ? ?/sec
u1024_div                 1.00   296.9±13.45ns        ? ?/sec    1.00   297.5±16.29ns        ? ?/sec
u1024_mul                 1.00   416.2±23.71ns        ? ?/sec    1.28   533.3±16.83ns        ? ?/sec
u1024_sub                 1.00     42.1±1.41ns        ? ?/sec    1.00     42.0±1.64ns        ? ?/sec
```

All these tests were run on my laptop, in a not very controlled environment, so your mileage may vary. But the big differences in the i1024 tests, and in `u1024_cmp_eq`, are quite robust. There's a big and robust improvement in `u1024_mul` too, although I don't fully understand where that's coming from.
