### PR TITLE
Separate Wrapper and WrapperMut

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "amplify_derive"
-version = "2.11.3"
+version = "4.0.0-alpha.1"
 dependencies = [
  "amplify",
  "amplify_syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ bench = false
 
 [dependencies]
 libc = { version = "0.2", optional = true }
-amplify_derive = { version = "2.10.0", path = "./derive", optional = true }
+amplify_derive = { version = "4.0.0-alpha.1", path = "./derive", optional = true }
 amplify_syn = { version = "1.1", path = "./syn", optional = true }
 amplify_num = { version = "0.4.0", path = "./num" }
 amplify_apfloat = { version = "0.1.1", path = "./apfloat", optional = true }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "amplify_derive"
-version = "2.11.3"
+version = "4.0.0-alpha.1"
 description = "Amplifying Rust language capabilities: derive macros for the 'amplify' library"
 authors = ["Dr. Maxim Orlovsky <orlovsky@pandoracore.com>", "Elichai Turkel <elichai.turkel@gmail.com>"]
 keywords = ["generics", "derive", "wrap", "patterns"]
-categories = ["data-structures", "rust-patterns"]
+categories = ["data-structures", "rust-patterns", "no_std"]
 repository = "https://github.com/rust-amplify/rust-amplify"
 homepage = "https://github.com/rust-amplify"
 license = "MIT"

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -665,36 +665,46 @@ pub fn derive_getters(input: TokenStream) -> TokenStream {
 ///
 /// You can implement additional derives, it they are implemented for the wrapped
 /// type, using `#[wrapper()]` proc macro:
-/// * [`core::ops::Deref`]
-/// * [`core::str::FromStr`]
-/// * [`std::fmt::Debug`]
-/// * [`std::fmt::Display`]
-/// * [`std::fmt::LowerHex`]
-/// * [`std::fmt::UpperHex`]
-/// * [`std::fmt::LowerExp`]
-/// * [`std::fmt::UpperExp`]
-/// * [`std::fmt::Octal`]
-/// * [`core::borrow::BorrowSlice`]
-/// * [`core::ops::Index`]
-// TODO: Switch Index* to Index for Range*
-/// * [`core::ops::IndexRange`]
-/// * [`core::ops::IndexTo`]
-/// * [`core::ops::IndexFrom`]
-/// * [`core::ops::IndexInclusive`]
-/// * [`core::ops::IndexToInclusive`]
-/// * [`core::ops::IndexFull`]
-/// * [`core::ops::Neg`]
-/// * [`core::ops::Add`]
-/// * [`core::ops::Sub`]
-/// * [`core::ops::Mul`]
-/// * [`core::ops::Div`]
-/// * [`core::ops::Rem`]
-/// * [`core::ops::Shl`]
-/// * [`core::ops::Shr`]
-/// * [`core::ops::Not`]
-/// * [`core::ops::BitAnd`]
-/// * [`core::ops::BitOr`]
-/// * [`core::ops::BitXor`]
+/// 1. Reference access to the inner type:
+///    * `Deref` for implementing [`core::ops::Deref`]
+///    * `BorrowSlice` for implementing [`core::borrow::Borrow`]`<[Self::Inner]>`
+/// 2. Formatting:
+///    * `FromStr` for implementing [`core::str::FromStr`]
+///    * `Debug` for implementing [`core::fmt::Debug`]
+///    * `Display` for implementing [`core::fmt::Display`]
+///    * `Deref` for implementing [`core::fmt::LowerHex`]
+///    * `LowerHex` for implementing [`core::fmt::UpperHex`]
+///    * `LowerExp` for implementing [`core::fmt::LowerExp`]
+///    * `UpperExp` for implementing [`core::fmt::UpperExp`]
+///    * `Octal` for implementing [`core::fmt::Octal`]
+/// 3. Indexed access to the inner type:
+///    * `Index` for implementing [`core::ops::Index`]`<usize>`
+///    * `IndexRange` for implementing
+///      [`core::ops::Index`]`<`[`core::ops::Range`]`<usize>>`
+///    * `IndexTo` for implementing
+///      [`core::ops::Index`]`<`[`core::ops::RangeTo`]`<usize>>`
+///    * `IndexFrom` for implementing
+///      [`core::ops::Index`]`<`[`core::ops::RangeFrom`]`<usize>>`
+///    * `IndexInclusive` for implementing
+///      [`core::ops::Index`]`<`[`core::ops::RangeInclusive`]`<usize>>`
+///    * `IndexToInclusive` for implementing
+///      [`core::ops::Index`]`<`[`core::ops::RangeToInclusive`]`<usize>>`
+///    * `IndexFull` for implementing
+///      [`core::ops::Index`]`<`[`core::ops::RangeFrom`]`<usize>>`
+/// 4. Arithmetic operations:
+///    * `Neg` for implementing [`core::ops::Neg`]
+///    * `Add` for implementing [`core::ops::Add`]
+///    * `Sub` for implementing [`core::ops::Sub`]
+///    * `Mul` for implementing [`core::ops::Mul`]
+///    * `Div` for implementing [`core::ops::Div`]
+///    * `Rem` for implementing [`core::ops::Rem`]
+/// 5. Boolean and bit-wise operations:
+///    * `Not` for implementing [`core::ops::Not`]
+///    * `BitAnd` for implementing [`core::ops::BitAnd`]
+///    * `BitOr` for implementing [`core::ops::BitOr`]
+///    * `BitXor` for implementing [`core::ops::BitXor`]
+///    * `Shl` for implementing [`core::ops::Shl`]
+///    * `Shr` for implementing [`core::ops::Shr`]
 ///
 /// There are shortcuts for derivations:
 /// * `#[wrapper(Hex)]` will derive both `LowerHex` and `UpperHex`;
@@ -783,26 +793,36 @@ pub fn derive_wrapper(input: TokenStream) -> TokenStream {
 ///
 /// You can implement additional derives, it they are implemented for the wrapped
 /// type, using `#[wrapper()]` proc macro:
-// TODO: Switch Index* to IndexMut for Range*
-/// * [`core::ops::DerefMut`]
-/// * [`core::borrow::BorrowSliceMut`]
-/// * [`core::ops::IndexMut`]
-/// * [`core::ops::IndexRangeMut`]
-/// * [`core::ops::IndexToMut`]
-/// * [`core::ops::IndexFromMut`]
-/// * [`core::ops::IndexInclusiveMut`]
-/// * [`core::ops::IndexToInclusiveMut`]
-/// * [`core::ops::IndexFull`]
-/// * [`core::ops::AddAssign`]
-/// * [`core::ops::SubAssign`]
-/// * [`core::ops::MulAssign`]
-/// * [`core::ops::DivAssign`]
-/// * [`core::ops::RemAssign`]
-/// * [`core::ops::ShlAssign`]
-/// * [`core::ops::ShrAssign`]
-/// * [`core::ops::BitAndAssign`]
-/// * [`core::ops::BitOrAssign`]
-/// * [`core::ops::BitXorAssign`]
+/// 1. Reference access to the inner type:
+///    * `DerefMut` for implementing [`core::ops::DerefMut`]
+///    * `BorrowSliceMut` for implementing
+///      [`core::borrow::BorrowMut`]`<[Self::Inner]>`
+/// 2. Indexed access to the inner type:
+///    * `IndexMut` for implementing [`core::ops::IndexMut`]`<usize>`
+///    * `IndexRangeMut` for implementing
+///      [`core::ops::IndexMut`]`<`[`core::ops::Range`]`<usize>>`
+///    * `IndexToMut` for implementing
+///      [`core::ops::IndexMut`]`<`[`core::ops::RangeTo`]`<usize>>`
+///    * `IndexFromMut` for implementing
+///      [`core::ops::IndexMut`]`<`[`core::ops::RangeFrom`]`<usize>>`
+///    * `IndexInclusiveMut` for implementing
+///      [`core::ops::IndexMut`]`<`[`core::ops::RangeInclusive`]`<usize>>`
+///    * `IndexToInclusiveMut` for implementing
+///      [`core::ops::IndexMut`]`<`[`core::ops::RangeToInclusive`]`<usize>>`
+///    * `IndexFullMut` for implementing
+///      [`core::ops::IndexMut`]`<`[`core::ops::RangeFrom`]`<usize>>`
+/// 3. Arithmetic operations:
+///    * `AddAssign` for implementing [`core::ops::AddAssign`]
+///    * `SubAssign` for implementing [`core::ops::SubAssign`]
+///    * `MulAssign` for implementing [`core::ops::MulAssign`]
+///    * `DivAssign` for implementing [`core::ops::DivAssign`]
+///    * `RemAssign` for implementing [`core::ops::RemAssign`]
+/// 4. Boolean and bit-wise operations:
+///    * `BitAndAssign` for implementing [`core::ops::BitAndAssign`]
+///    * `BitOrAssign` for implementing [`core::ops::BitOrAssign`]
+///    * `BitXorAssign` for implementing [`core::ops::BitXorAssign`]
+///    * `ShlAssign` for implementing [`core::ops::ShlAssign`]
+///    * `ShrAssign` for implementing [`core::ops::ShrAssign`]
 ///
 /// There are shortcuts for derivations:
 /// * `#[wrapper(IndexRangesMut)]` will derive all index traits working with

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -711,7 +711,7 @@ pub fn derive_getters(input: TokenStream) -> TokenStream {
 /// * `#[wrapper(Exp)]` will derive both `LowerExp` and `UpperExp`;
 /// * `#[wrapper(NumberFmt)]` will derive all number formatting traits
 ///    (`LowerHex`, `UpperHex`, `LowerExp`, `UpperExp`, `Octal`);
-/// * `#[wrapper(IndexRanges)]` will derive all index traits working with ranges
+/// * `#[wrapper(RangeOps)]` will derive all index traits working with ranges
 ///    (`IndexRange`, `IndexTo`, `IndexFrom`, `IndexInclusive`,
 ///    `IndexToInclusive`, `IndexFull`);
 /// * `#[wrapper(MathOps)]` will derive all arithmetic operations
@@ -737,8 +737,7 @@ pub fn derive_getters(input: TokenStream) -> TokenStream {
 /// )]
 /// #[display(inner)]
 /// #[wrapper(LowerHex, UpperHex, Octal)]
-/// #[wrapper(Neg, Add, Sub, Div, Mul, Rem)]
-/// #[wrapper(Not, Shl, Shr, BitAnd, BitOr, BitXor)]
+/// #[wrapper(MathOps, BitOps)]
 /// struct Int64(i64);
 /// ```
 ///
@@ -771,7 +770,7 @@ pub fn derive_getters(input: TokenStream) -> TokenStream {
 /// use amplify::Wrapper;
 ///
 /// #[derive(Wrapper, From)]
-/// #[wrapper(Index, IndexRange, IndexFrom, IndexTo, IndexInclusive, IndexFull)]
+/// #[wrapper(Index, RangeOps)]
 /// struct VecNewtype(Vec<u8>);
 /// ```
 #[proc_macro_derive(Wrapper, attributes(wrap, wrapper, amplify_crate))]
@@ -825,7 +824,7 @@ pub fn derive_wrapper(input: TokenStream) -> TokenStream {
 ///    * `ShrAssign` for implementing [`core::ops::ShrAssign`]
 ///
 /// There are shortcuts for derivations:
-/// * `#[wrapper(IndexRangesMut)]` will derive all index traits working with
+/// * `#[wrapper(RangeMut)]` will derive all index traits working with
 ///    ranges (`IndexRangeMut`, `IndexToMut`, `IndexFromMut`,
 ///    `IndexInclusiveMut`, `IndexToInclusiveMut`, `IndexFullMut`);
 /// * `#[wrapper(MathAssign)]` will derive all arithmetic operations
@@ -847,11 +846,8 @@ pub fn derive_wrapper(input: TokenStream) -> TokenStream {
 ///     Display,
 /// )]
 /// #[display(inner)]
-/// #[wrapper(LowerHex, UpperHex, Octal)]
-/// #[wrapper(Neg, Add, Sub, Div, Mul, Rem)]
-/// #[wrapper_mut(AddAssign, SubAssign, DivAssign, MulAssign, RemAssign)]
-/// #[wrapper(Not, Shl, Shr, BitAnd, BitOr, BitXor)]
-/// #[wrapper_mut(ShlAssign, ShrAssign, BitAndAssign, BitOrAssign, BitXorAssign)]
+/// #[wrapper(NumberFmt, MathOps, BoolOps)]
+/// #[wrapper_mut(MathAssign, BitAssign)]
 /// struct Int64(i64);
 /// ```
 #[proc_macro_derive(WrapperMut, attributes(wrap, wrapper_mut, amplify_crate))]

--- a/derive/src/wrapper.rs
+++ b/derive/src/wrapper.rs
@@ -60,6 +60,7 @@ enum Wrapper {
     BitAnd,
     BitOr,
     BitXor,
+    // Group operations
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]

--- a/derive/src/wrapper.rs
+++ b/derive/src/wrapper.rs
@@ -13,10 +13,10 @@
 // along with this software.
 // If not, see <https://opensource.org/licenses/MIT>.
 
-use proc_macro2::TokenStream as TokenStream2;
+use proc_macro2::{TokenStream as TokenStream2};
 use syn::{
     DeriveInput, Result, Data, Error, Fields, Index, Meta, MetaList, Path, NestedMeta,
-    spanned::Spanned,
+    spanned::Spanned, Type,
 };
 
 use crate::util::get_amplify_crate;
@@ -25,7 +25,8 @@ const NAME: &str = "wrapper";
 const EXAMPLE: &str = r#"#[wrapper(LowerHex, Add)]"#;
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
-enum WrapperDerives {
+enum Wrapper {
+    // Formatting
     FromStr,
     Display,
     Debug,
@@ -34,26 +35,47 @@ enum WrapperDerives {
     UpperHex,
     LowerExp,
     UpperExp,
+    // References
+    Deref,
     BorrowSlice,
+    // Indexes
     Index,
-    IndexMut,
     IndexRange,
     IndexFull,
     IndexFrom,
     IndexTo,
     IndexInclusive,
+    IndexToInclusive,
+    // Arithmetics
     Neg,
-    Not,
     Add,
     Sub,
     Mul,
     Div,
     Rem,
+    // Booleans
+    Not,
     Shl,
     Shr,
     BitAnd,
     BitOr,
     BitXor,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+enum WrapperMut {
+    // References
+    DerefMut,
+    BorrowSliceMut,
+    // Indexes
+    IndexMut,
+    IndexRangeMut,
+    IndexFullMut,
+    IndexFromMut,
+    IndexToMut,
+    IndexInclusiveMut,
+    IndexToInclusiveMut,
+    // Arithmetics
     AddAssign,
     SubAssign,
     MulAssign,
@@ -61,13 +83,23 @@ enum WrapperDerives {
     RemAssign,
     ShlAssign,
     ShrAssign,
+    // Booleans
     BitAndAssign,
     BitOrAssign,
     BitXorAssign,
 }
 
-impl WrapperDerives {
-    pub fn from_path(path: &Path) -> Result<Option<Self>> {
+pub trait FromPath: Sized {
+    const IDENT: &'static str;
+    const DERIVE: &'static str;
+    fn from_path(path: &Path) -> Result<Option<Self>>;
+}
+
+impl FromPath for Wrapper {
+    const IDENT: &'static str = "wrapper";
+    const DERIVE: &'static str = "Wrapper";
+
+    fn from_path(path: &Path) -> Result<Option<Self>> {
         path.segments.first().map_or(
             Err(attr_err!(
                 path.span(),
@@ -77,50 +109,43 @@ impl WrapperDerives {
             )),
             |segment| {
                 Ok(match segment.ident.to_string().as_str() {
-                    "FromStr" => Some(WrapperDerives::FromStr),
-                    "Display" => Some(WrapperDerives::Display),
-                    "Debug" => Some(WrapperDerives::Debug),
-                    "Octal" => Some(WrapperDerives::Octal),
-                    "LowerHex" => Some(WrapperDerives::LowerHex),
-                    "UpperHex" => Some(WrapperDerives::UpperHex),
-                    "LowerExp" => Some(WrapperDerives::LowerExp),
-                    "UpperExp" => Some(WrapperDerives::UpperExp),
-                    "BorrowSlice" => Some(WrapperDerives::BorrowSlice),
-                    "Index" => Some(WrapperDerives::Index),
-                    "IndexMut" => Some(WrapperDerives::IndexMut),
-                    "IndexRange" => Some(WrapperDerives::IndexRange),
-                    "IndexFull" => Some(WrapperDerives::IndexFull),
-                    "IndexFrom" => Some(WrapperDerives::IndexFrom),
-                    "IndexTo" => Some(WrapperDerives::IndexTo),
-                    "IndexInclusive" => Some(WrapperDerives::IndexInclusive),
-                    "Add" => Some(WrapperDerives::Add),
-                    "Neg" => Some(WrapperDerives::Neg),
-                    "Not" => Some(WrapperDerives::Not),
-                    "Sub" => Some(WrapperDerives::Sub),
-                    "Mul" => Some(WrapperDerives::Mul),
-                    "Div" => Some(WrapperDerives::Div),
-                    "Rem" => Some(WrapperDerives::Rem),
-                    "Shl" => Some(WrapperDerives::Shl),
-                    "Shr" => Some(WrapperDerives::Shr),
-                    "BitAnd" => Some(WrapperDerives::BitAnd),
-                    "BitOr" => Some(WrapperDerives::BitOr),
-                    "BitXor" => Some(WrapperDerives::BitXor),
-                    "AddAssign" => Some(WrapperDerives::AddAssign),
-                    "SubAssign" => Some(WrapperDerives::SubAssign),
-                    "MulAssign" => Some(WrapperDerives::MulAssign),
-                    "DivAssign" => Some(WrapperDerives::DivAssign),
-                    "RemAssign" => Some(WrapperDerives::RemAssign),
-                    "ShlAssign" => Some(WrapperDerives::ShlAssign),
-                    "ShrAssign" => Some(WrapperDerives::ShrAssign),
-                    "BitAndAssign" => Some(WrapperDerives::BitAndAssign),
-                    "BitOrAssign" => Some(WrapperDerives::BitOrAssign),
-                    "BitXorAssign" => Some(WrapperDerives::BitXorAssign),
+                    "FromStr" => Some(Wrapper::FromStr),
+                    "Display" => Some(Wrapper::Display),
+                    "Debug" => Some(Wrapper::Debug),
+                    "Octal" => Some(Wrapper::Octal),
+                    "LowerHex" => Some(Wrapper::LowerHex),
+                    "UpperHex" => Some(Wrapper::UpperHex),
+                    "LowerExp" => Some(Wrapper::LowerExp),
+                    "UpperExp" => Some(Wrapper::UpperExp),
+                    "Deref" => Some(Wrapper::Deref),
+                    "BorrowSlice" => Some(Wrapper::BorrowSlice),
+                    "Index" => Some(Wrapper::Index),
+                    "IndexRange" => Some(Wrapper::IndexRange),
+                    "IndexFull" => Some(Wrapper::IndexFull),
+                    "IndexFrom" => Some(Wrapper::IndexFrom),
+                    "IndexTo" => Some(Wrapper::IndexTo),
+                    "IndexInclusive" => Some(Wrapper::IndexInclusive),
+                    "IndexToInclusive" => Some(Wrapper::IndexToInclusive),
+                    "Add" => Some(Wrapper::Add),
+                    "Neg" => Some(Wrapper::Neg),
+                    "Not" => Some(Wrapper::Not),
+                    "Sub" => Some(Wrapper::Sub),
+                    "Mul" => Some(Wrapper::Mul),
+                    "Div" => Some(Wrapper::Div),
+                    "Rem" => Some(Wrapper::Rem),
+                    "Shl" => Some(Wrapper::Shl),
+                    "Shr" => Some(Wrapper::Shr),
+                    "BitAnd" => Some(Wrapper::BitAnd),
+                    "BitOr" => Some(Wrapper::BitOr),
+                    "BitXor" => Some(Wrapper::BitXor),
                     _ => None,
                 })
             },
         )
     }
+}
 
+impl Wrapper {
     pub fn into_token_stream2(self, input: &DeriveInput) -> TokenStream2 {
         let impl_generics_params = input.generics.params.clone();
         let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
@@ -128,7 +153,7 @@ impl WrapperDerives {
         let amplify_crate = get_amplify_crate(input);
 
         match self {
-            WrapperDerives::FromStr => quote! {
+            Wrapper::FromStr => quote! {
                 impl #impl_generics ::core::str::FromStr for #ident_name #ty_generics #where_clause
                 {
                     type Err = <<Self as #amplify_crate::Wrapper>::Inner as ::core::str::FromStr>::Err;
@@ -143,7 +168,7 @@ impl WrapperDerives {
                     }
                 }
             },
-            WrapperDerives::Display => quote! {
+            Wrapper::Display => quote! {
                 impl #impl_generics ::core::fmt::Display for #ident_name #ty_generics #where_clause
                 {
                     #[inline]
@@ -153,7 +178,7 @@ impl WrapperDerives {
                     }
                 }
             },
-            WrapperDerives::Debug => quote! {
+            Wrapper::Debug => quote! {
                 impl #impl_generics ::core::fmt::Debug for #ident_name #ty_generics #where_clause
                 {
                     #[inline]
@@ -163,7 +188,7 @@ impl WrapperDerives {
                     }
                 }
             },
-            WrapperDerives::Octal => quote! {
+            Wrapper::Octal => quote! {
                 impl #impl_generics ::core::fmt::Octal for #ident_name #ty_generics #where_clause
                 {
                     #[inline]
@@ -173,7 +198,7 @@ impl WrapperDerives {
                     }
                 }
             },
-            WrapperDerives::LowerHex => quote! {
+            Wrapper::LowerHex => quote! {
                 impl #impl_generics ::core::fmt::LowerHex for #ident_name #ty_generics #where_clause
                 {
                     #[inline]
@@ -183,7 +208,7 @@ impl WrapperDerives {
                     }
                 }
             },
-            WrapperDerives::UpperHex => quote! {
+            Wrapper::UpperHex => quote! {
                 impl #impl_generics ::core::fmt::UpperHex for #ident_name #ty_generics #where_clause
                 {
                     #[inline]
@@ -193,7 +218,7 @@ impl WrapperDerives {
                     }
                 }
             },
-            WrapperDerives::LowerExp => quote! {
+            Wrapper::LowerExp => quote! {
                 impl #impl_generics ::core::fmt::LowerExp for #ident_name #ty_generics #where_clause
                 {
                     #[inline]
@@ -203,7 +228,7 @@ impl WrapperDerives {
                     }
                 }
             },
-            WrapperDerives::UpperExp => quote! {
+            Wrapper::UpperExp => quote! {
                 impl #impl_generics ::core::fmt::UpperExp for #ident_name #ty_generics #where_clause
                 {
                     #[inline]
@@ -213,7 +238,18 @@ impl WrapperDerives {
                     }
                 }
             },
-            WrapperDerives::BorrowSlice => quote! {
+            Wrapper::Deref => quote! {
+                impl #impl_generics ::core::ops::Deref for #ident_name #ty_generics #where_clause
+                {
+                    type Target = <Self as #amplify_crate::Wrapper>::Inner;
+                    #[inline]
+                    fn deref(&self) -> &Self::Target {
+                        use #amplify_crate::Wrapper;
+                        Wrapper::as_inner(self)
+                    }
+                }
+            },
+            Wrapper::BorrowSlice => quote! {
                 impl #impl_generics ::core::borrow::Borrow<[u8]> for #ident_name #ty_generics #where_clause
                 {
                     #[inline]
@@ -223,7 +259,7 @@ impl WrapperDerives {
                     }
                 }
             },
-            WrapperDerives::Index => {
+            Wrapper::Index => {
                 let where_clause = match where_clause {
                     None => quote! { where },
                     Some(_) => quote! { #where_clause },
@@ -241,23 +277,7 @@ impl WrapperDerives {
                     }
                 }
             }
-            WrapperDerives::IndexMut => {
-                let where_clause = match where_clause {
-                    None => quote! { where },
-                    Some(_) => quote! { #where_clause },
-                };
-                quote! {
-                    impl <#impl_generics_params> ::core::ops::IndexMut<usize> for #ident_name #ty_generics #where_clause
-                    {
-                        #[inline]
-                        fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-                            use #amplify_crate::Wrapper;
-                            Wrapper::as_inner_mut(self).index_mut(index)
-                        }
-                    }
-                }
-            }
-            WrapperDerives::IndexRange => {
+            Wrapper::IndexRange => {
                 quote! {
                     impl <#impl_generics_params> ::core::ops::Index<::core::ops::Range<usize>> for #ident_name #ty_generics #where_clause
                     {
@@ -271,7 +291,7 @@ impl WrapperDerives {
                     }
                 }
             }
-            WrapperDerives::IndexFrom => {
+            Wrapper::IndexFrom => {
                 quote! {
                     impl <#impl_generics_params> ::core::ops::Index<::core::ops::RangeFrom<usize>> for #ident_name #ty_generics #where_clause
                     {
@@ -285,7 +305,7 @@ impl WrapperDerives {
                     }
                 }
             }
-            WrapperDerives::IndexTo => {
+            Wrapper::IndexTo => {
                 quote! {
                     impl <#impl_generics_params> ::core::ops::Index<::core::ops::RangeTo<usize>> for #ident_name #ty_generics #where_clause
                     {
@@ -299,7 +319,7 @@ impl WrapperDerives {
                     }
                 }
             }
-            WrapperDerives::IndexInclusive => {
+            Wrapper::IndexInclusive => {
                 quote! {
                     impl <#impl_generics_params> ::core::ops::Index<::core::ops::RangeInclusive<usize>> for #ident_name #ty_generics #where_clause
                     {
@@ -313,7 +333,21 @@ impl WrapperDerives {
                     }
                 }
             }
-            WrapperDerives::IndexFull => {
+            Wrapper::IndexToInclusive => {
+                quote! {
+                    impl <#impl_generics_params> ::core::ops::Index<::core::ops::RangeToInclusive<usize>> for #ident_name #ty_generics #where_clause
+                    {
+                        type Output = <<Self as #amplify_crate::Wrapper>::Inner as ::core::ops::Index<::core::ops::RangeInclusive<usize>>>::Output;
+
+                        #[inline]
+                        fn index(&self, index: ::core::ops::RangeToInclusive<usize>) -> &Self::Output {
+                            use #amplify_crate::Wrapper;
+                            Wrapper::as_inner(self).index(index)
+                        }
+                    }
+                }
+            }
+            Wrapper::IndexFull => {
                 quote! {
                     impl <#impl_generics_params> ::core::ops::Index<::core::ops::RangeFull> for #ident_name #ty_generics #where_clause
                     {
@@ -327,7 +361,7 @@ impl WrapperDerives {
                     }
                 }
             }
-            WrapperDerives::Neg => quote! {
+            Wrapper::Neg => quote! {
                 impl #impl_generics ::core::ops::Neg for #ident_name #ty_generics #where_clause
                 {
                     type Output = Self;
@@ -339,7 +373,7 @@ impl WrapperDerives {
                     }
                 }
             },
-            WrapperDerives::Not => quote! {
+            Wrapper::Not => quote! {
                 impl #impl_generics ::core::ops::Not for #ident_name #ty_generics #where_clause
                 {
                     type Output = Self;
@@ -351,7 +385,7 @@ impl WrapperDerives {
                     }
                 }
             },
-            WrapperDerives::Add => quote! {
+            Wrapper::Add => quote! {
                 impl #impl_generics ::core::ops::Add for #ident_name #ty_generics #where_clause
                 {
                     type Output = Self;
@@ -363,7 +397,7 @@ impl WrapperDerives {
                     }
                 }
             },
-            WrapperDerives::Sub => quote! {
+            Wrapper::Sub => quote! {
                 impl #impl_generics ::core::ops::Sub for #ident_name #ty_generics #where_clause
                 {
                     type Output = Self;
@@ -375,7 +409,7 @@ impl WrapperDerives {
                     }
                 }
             },
-            WrapperDerives::Mul => quote! {
+            Wrapper::Mul => quote! {
                 impl #impl_generics ::core::ops::Mul for #ident_name #ty_generics #where_clause
                 {
                     type Output = Self;
@@ -387,7 +421,7 @@ impl WrapperDerives {
                     }
                 }
             },
-            WrapperDerives::Div => quote! {
+            Wrapper::Div => quote! {
                 impl #impl_generics ::core::ops::Div for #ident_name #ty_generics #where_clause
                 {
                     type Output = Self;
@@ -399,7 +433,7 @@ impl WrapperDerives {
                     }
                 }
             },
-            WrapperDerives::Rem => quote! {
+            Wrapper::Rem => quote! {
                 impl #impl_generics ::core::ops::Rem for #ident_name #ty_generics #where_clause
                 {
                     type Output = Self;
@@ -411,7 +445,7 @@ impl WrapperDerives {
                     }
                 }
             },
-            WrapperDerives::Shl => quote! {
+            Wrapper::Shl => quote! {
                 impl #impl_generics ::core::ops::Shl for #ident_name #ty_generics #where_clause
                 {
                     type Output = Self;
@@ -423,7 +457,7 @@ impl WrapperDerives {
                     }
                 }
             },
-            WrapperDerives::Shr => quote! {
+            Wrapper::Shr => quote! {
                 impl #impl_generics ::core::ops::Shr for #ident_name #ty_generics #where_clause
                 {
                     type Output = Self;
@@ -435,7 +469,7 @@ impl WrapperDerives {
                     }
                 }
             },
-            WrapperDerives::BitAnd => quote! {
+            Wrapper::BitAnd => quote! {
                 impl #impl_generics ::core::ops::BitAnd for #ident_name #ty_generics #where_clause
                 {
                     type Output = Self;
@@ -447,7 +481,7 @@ impl WrapperDerives {
                     }
                 }
             },
-            WrapperDerives::BitOr => quote! {
+            Wrapper::BitOr => quote! {
                 impl #impl_generics ::core::ops::BitOr for #ident_name #ty_generics #where_clause
                 {
                     type Output = Self;
@@ -459,7 +493,7 @@ impl WrapperDerives {
                     }
                 }
             },
-            WrapperDerives::BitXor => quote! {
+            Wrapper::BitXor => quote! {
                 impl #impl_generics ::core::ops::BitXor for #ident_name #ty_generics #where_clause
                 {
                     type Output = Self;
@@ -471,103 +505,263 @@ impl WrapperDerives {
                     }
                 }
             },
-            WrapperDerives::AddAssign => quote! {
+        }
+    }
+}
+
+impl FromPath for WrapperMut {
+    const IDENT: &'static str = "wrapper_mut";
+    const DERIVE: &'static str = "WrapperMut";
+
+    fn from_path(path: &Path) -> Result<Option<Self>> {
+        path.segments.first().map_or(
+            Err(attr_err!(
+                path.span(),
+                NAME,
+                "must contain at least one identifier",
+                EXAMPLE
+            )),
+            |segment| {
+                Ok(match segment.ident.to_string().as_str() {
+                    "DerefMut" => Some(WrapperMut::DerefMut),
+                    "BorrowSliceMut" => Some(WrapperMut::BorrowSliceMut),
+                    "IndexMut" => Some(WrapperMut::IndexMut),
+                    "IndexRangeMut" => Some(WrapperMut::IndexRangeMut),
+                    "IndexFullMut" => Some(WrapperMut::IndexFullMut),
+                    "IndexFromMut" => Some(WrapperMut::IndexFromMut),
+                    "IndexToMut" => Some(WrapperMut::IndexToMut),
+                    "IndexInclusiveMut" => Some(WrapperMut::IndexInclusiveMut),
+                    "IndexToInclusiveMut" => Some(WrapperMut::IndexToInclusiveMut),
+                    "AddAssign" => Some(WrapperMut::AddAssign),
+                    "SubAssign" => Some(WrapperMut::SubAssign),
+                    "MulAssign" => Some(WrapperMut::MulAssign),
+                    "DivAssign" => Some(WrapperMut::DivAssign),
+                    "RemAssign" => Some(WrapperMut::RemAssign),
+                    "ShlAssign" => Some(WrapperMut::ShlAssign),
+                    "ShrAssign" => Some(WrapperMut::ShrAssign),
+                    "BitAndAssign" => Some(WrapperMut::BitAndAssign),
+                    "BitOrAssign" => Some(WrapperMut::BitOrAssign),
+                    "BitXorAssign" => Some(WrapperMut::BitXorAssign),
+                    _ => None,
+                })
+            },
+        )
+    }
+}
+
+impl WrapperMut {
+    pub fn into_token_stream2(self, input: &DeriveInput) -> TokenStream2 {
+        let impl_generics_params = input.generics.params.clone();
+        let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+        let ident_name = &input.ident;
+        let amplify_crate = get_amplify_crate(input);
+
+        match self {
+            WrapperMut::DerefMut => quote! {
+                impl #impl_generics ::core::ops::DerefMut for #ident_name #ty_generics #where_clause
+                {
+                    #[inline]
+                    fn deref_mut(&mut self) -> &mut Self::Target {
+                        use #amplify_crate::WrapperMut;
+                        WrapperMut::as_inner_mut(self)
+                    }
+                }
+            },
+            WrapperMut::BorrowSliceMut => quote! {
+                impl #impl_generics ::core::borrow::BorrowMut<[u8]> for #ident_name #ty_generics #where_clause
+                {
+                    #[inline]
+                    fn borrow_mut(&self) -> &mut [u8] {
+                        use #amplify_crate::WrapperMut;
+                        ::core::borrow::BorrowMut::<[u8]>::borrow_mut(WrapperMut::as_inner_mut(self))
+                    }
+                }
+            },
+            WrapperMut::IndexMut => {
+                let where_clause = match where_clause {
+                    None => quote! { where },
+                    Some(_) => quote! { #where_clause },
+                };
+                quote! {
+                    impl <#impl_generics_params> ::core::ops::IndexMut<usize> for #ident_name #ty_generics #where_clause
+                    {
+                        #[inline]
+                        fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+                            use #amplify_crate::WrapperMut;
+                            WrapperMut::as_inner_mut(self).index_mut(index)
+                        }
+                    }
+                }
+            }
+            WrapperMut::IndexRangeMut => {
+                quote! {
+                    impl <#impl_generics_params> ::core::ops::IndexMut<::core::ops::Range<usize>> for #ident_name #ty_generics #where_clause
+                    {
+                        #[inline]
+                        fn index_mut(&mut self, index: ::core::ops::Range<usize>) -> &mut Self::Output {
+                            use #amplify_crate::WrapperMut;
+                            WrapperMut::as_inner_mut(self).index_mut(index)
+                        }
+                    }
+                }
+            }
+            WrapperMut::IndexFromMut => {
+                quote! {
+                    impl <#impl_generics_params> ::core::ops::IndexMut<::core::ops::RangeFrom<usize>> for #ident_name #ty_generics #where_clause
+                    {
+                        #[inline]
+                        fn index_mut(&mut self, index: ::core::ops::RangeFrom<usize>) -> &mut Self::Output {
+                            use #amplify_crate::WrapperMut;
+                            WrapperMut::as_inner_mut(self).index_mut(index)
+                        }
+                    }
+                }
+            }
+            WrapperMut::IndexToMut => {
+                quote! {
+                    impl <#impl_generics_params> ::core::ops::IndexMut<::core::ops::RangeTo<usize>> for #ident_name #ty_generics #where_clause
+                    {
+                        #[inline]
+                        fn index_mut(&mut self, index: ::core::ops::RangeTo<usize>) -> &mut Self::Output {
+                            use #amplify_crate::WrapperMut;
+                            WrapperMut::as_inner_mut(self).index_mut(index)
+                        }
+                    }
+                }
+            }
+            WrapperMut::IndexInclusiveMut => {
+                quote! {
+                    impl <#impl_generics_params> ::core::ops::IndexMut<::core::ops::RangeInclusive<usize>> for #ident_name #ty_generics #where_clause
+                    {
+                        #[inline]
+                        fn index_mut(&mut self, index: ::core::ops::RangeInclusive<usize>) -> &mut Self::Output {
+                            use #amplify_crate::WrapperMut;
+                            WrapperMut::as_inner_mut(self).index_mut(index)
+                        }
+                    }
+                }
+            }
+            WrapperMut::IndexToInclusiveMut => {
+                quote! {
+                    impl <#impl_generics_params> ::core::ops::IndexMut<::core::ops::RangeToInclusive<usize>> for #ident_name #ty_generics #where_clause
+                    {
+                        #[inline]
+                        fn index_mut(&mut self, index: ::core::ops::RangeToInclusive<usize>) -> &mut Self::Output {
+                            use #amplify_crate::WrapperMut;
+                            WrapperMut::as_inner_mut(self).index_mut(index)
+                        }
+                    }
+                }
+            }
+            WrapperMut::IndexFullMut => {
+                quote! {
+                    impl <#impl_generics_params> ::core::ops::IndexMut<::core::ops::RangeFull> for #ident_name #ty_generics #where_clause
+                    {
+                        #[inline]
+                        fn index_mut(&mut self, index: ::core::ops::RangeFull) -> &mut Self::Output {
+                            use #amplify_crate::WrapperMut;
+                            WrapperMut::as_inner_mut(self).index_mut(index)
+                        }
+                    }
+                }
+            }
+            WrapperMut::AddAssign => quote! {
                 impl #impl_generics ::core::ops::AddAssign for #ident_name #ty_generics #where_clause
                 {
                     #[inline]
                     fn add_assign(&mut self, rhs: Self) {
-                        use #amplify_crate::Wrapper;
-                        ::core::ops::AddAssign::add_assign(Wrapper::as_inner_mut(self), rhs.into_inner())
+                        use #amplify_crate::{Wrapper, WrapperMut};
+                        ::core::ops::AddAssign::add_assign(WrapperMut::as_inner_mut(self), rhs.into_inner())
                     }
                 }
             },
-            WrapperDerives::SubAssign => quote! {
+            WrapperMut::SubAssign => quote! {
                 impl #impl_generics ::core::ops::SubAssign for #ident_name #ty_generics #where_clause
                 {
                     #[inline]
                     fn sub_assign(&mut self, rhs: Self) {
-                        use #amplify_crate::Wrapper;
-                        ::core::ops::SubAssign::sub_assign(Wrapper::as_inner_mut(self), rhs.into_inner())
+                        use #amplify_crate::{Wrapper, WrapperMut};
+                        ::core::ops::SubAssign::sub_assign(WrapperMut::as_inner_mut(self), rhs.into_inner())
                     }
                 }
             },
-            WrapperDerives::MulAssign => quote! {
+            WrapperMut::MulAssign => quote! {
                 impl #impl_generics ::core::ops::MulAssign for #ident_name #ty_generics #where_clause
                 {
                     #[inline]
                     fn mul_assign(&mut self, rhs: Self) {
-                        use #amplify_crate::Wrapper;
-                        ::core::ops::MulAssign::mul_assign(Wrapper::as_inner_mut(self), rhs.into_inner())
+                        use #amplify_crate::{Wrapper, WrapperMut};
+                        ::core::ops::MulAssign::mul_assign(WrapperMut::as_inner_mut(self), rhs.into_inner())
                     }
                 }
             },
-            WrapperDerives::DivAssign => quote! {
+            WrapperMut::DivAssign => quote! {
                 impl #impl_generics ::core::ops::DivAssign for #ident_name #ty_generics #where_clause
                 {
                     #[inline]
                     fn div_assign(&mut self, rhs: Self) {
-                        use #amplify_crate::Wrapper;
-                        ::core::ops::DivAssign::div_assign(Wrapper::as_inner_mut(self), rhs.into_inner())
+                        use #amplify_crate::{Wrapper, WrapperMut};
+                        ::core::ops::DivAssign::div_assign(WrapperMut::as_inner_mut(self), rhs.into_inner())
                     }
                 }
             },
-            WrapperDerives::RemAssign => quote! {4
+            WrapperMut::RemAssign => quote! {4
                 impl #impl_generics ::core::ops::RemAssign for #ident_name #ty_generics #where_clause
                 {
                     #[inline]
                     fn rem_assign(&mut self, rhs: Self) {
-                        use #amplify_crate::Wrapper;
-                        ::core::ops::RemAssign::rem_assign(Wrapper::as_inner_mut(self), rhs.into_inner())
+                        use #amplify_crate::{Wrapper, WrapperMut};
+                        ::core::ops::RemAssign::rem_assign(WrapperMut::as_inner_mut(self), rhs.into_inner())
                     }
                 }
             },
-            WrapperDerives::ShlAssign => quote! {
+            WrapperMut::ShlAssign => quote! {
                 impl #impl_generics ::core::ops::ShlAssign for #ident_name #ty_generics #where_clause
                 {
                     #[inline]
                     fn shl_assign(&mut self, rhs: Self) {
-                        use #amplify_crate::Wrapper;
-                        ::core::ops::ShlAssign::shl_assign(Wrapper::as_inner_mut(self), rhs.into_inner())
+                        use #amplify_crate::{Wrapper, WrapperMut};
+                        ::core::ops::ShlAssign::shl_assign(WrapperMut::as_inner_mut(self), rhs.into_inner())
                     }
                 }
             },
-            WrapperDerives::ShrAssign => quote! {
+            WrapperMut::ShrAssign => quote! {
                 impl #impl_generics ::core::ops::ShrAssign for #ident_name #ty_generics #where_clause
                 {
                     #[inline]
                     fn shr_assign(&mut self, rhs: Self) {
-                        use #amplify_crate::Wrapper;
-                        ::core::ops::ShrAssign::shr_assign(Wrapper::as_inner_mut(self), rhs.into_inner())
+                        use #amplify_crate::{Wrapper, WrapperMut};
+                        ::core::ops::ShrAssign::shr_assign(WrapperMut::as_inner_mut(self), rhs.into_inner())
                     }
                 }
             },
-            WrapperDerives::BitAndAssign => quote! {
+            WrapperMut::BitAndAssign => quote! {
                 impl #impl_generics ::core::ops::BitAndAssign for #ident_name #ty_generics #where_clause
                 {
                     #[inline]
                     fn bitand_assign(&mut self, rhs: Self) {
-                        use #amplify_crate::Wrapper;
-                        ::core::ops::BitAndAssign::bitand_assign(Wrapper::as_inner_mut(self), rhs.into_inner())
+                        use #amplify_crate::{Wrapper, WrapperMut};
+                        ::core::ops::BitAndAssign::bitand_assign(WrapperMut::as_inner_mut(self), rhs.into_inner())
                     }
                 }
             },
-            WrapperDerives::BitOrAssign => quote! {
+            WrapperMut::BitOrAssign => quote! {
                 impl #impl_generics ::core::ops::BitOrAssign for #ident_name #ty_generics #where_clause
                 {
                     #[inline]
                     fn bitor_assign(&mut self, rhs: Self) {
-                        use #amplify_crate::Wrapper;
-                        ::core::ops::BitOrAssign::bitor_assign(Wrapper::as_inner_mut(self), rhs.into_inner())
+                        use #amplify_crate::{Wrapper, WrapperMut};
+                        ::core::ops::BitOrAssign::bitor_assign(WrapperMut::as_inner_mut(self), rhs.into_inner())
                     }
                 }
             },
-            WrapperDerives::BitXorAssign => quote! {
+            WrapperMut::BitXorAssign => quote! {
                 impl #impl_generics ::core::ops::BitXorAssign for #ident_name #ty_generics #where_clause
                 {
                     #[inline]
                     fn bitxor_assign(&mut self, rhs: Self) {
-                        use #amplify_crate::Wrapper;
-                        ::core::ops::BitXorAssign::bitxor_assign(Wrapper::as_inner_mut(self), rhs.into_inner())
+                        use #amplify_crate::{Wrapper, WrapperMut};
+                        ::core::ops::BitXorAssign::bitxor_assign(WrapperMut::as_inner_mut(self), rhs.into_inner())
                     }
                 }
             },
@@ -580,6 +774,98 @@ pub(crate) fn inner(input: DeriveInput) -> Result<TokenStream2> {
     let ident_name = &input.ident;
     let amplify_crate = get_amplify_crate(&input);
 
+    let (field, from) = get_params(&input)?;
+
+    let wrappers = get_wrappers::<Wrapper>(&input)?;
+    let wrapper_derive = wrappers.iter().map(|w| w.into_token_stream2(&input));
+
+    Ok(quote! {
+        impl #impl_generics #amplify_crate::Wrapper for #ident_name #ty_generics #where_clause {
+            type Inner = #from;
+
+            #[inline]
+            fn from_inner(inner: Self::Inner) -> Self {
+                Self::from(inner)
+            }
+
+            #[inline]
+            fn as_inner(&self) -> &Self::Inner {
+                &self.#field
+            }
+
+            #[inline]
+            fn into_inner(self) -> Self::Inner {
+                self.#field
+            }
+        }
+
+        impl #impl_generics ::core::convert::From<#ident_name #ty_generics> for #from #where_clause {
+            #[inline]
+            fn from(wrapped: #ident_name #ty_generics) -> Self {
+                use #amplify_crate::Wrapper;
+                Wrapper::into_inner(wrapped)
+            }
+        }
+
+        impl #impl_generics ::core::convert::AsRef<<#ident_name #impl_generics as #amplify_crate::Wrapper>::Inner> for #ident_name #ty_generics #where_clause {
+            #[inline]
+            fn as_ref(&self) -> &<Self as #amplify_crate::Wrapper>::Inner {
+                use #amplify_crate::Wrapper;
+                Wrapper::as_inner(self)
+            }
+        }
+
+        impl #impl_generics ::core::borrow::Borrow<<#ident_name #impl_generics as #amplify_crate::Wrapper>::Inner> for #ident_name #ty_generics #where_clause {
+            #[inline]
+            fn borrow(&self) -> &<Self as #amplify_crate::Wrapper>::Inner {
+                use #amplify_crate::Wrapper;
+                Wrapper::as_inner(self)
+            }
+        }
+
+        #( #wrapper_derive )*
+    })
+}
+
+pub(crate) fn inner_mut(input: DeriveInput) -> Result<TokenStream2> {
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+    let ident_name = &input.ident;
+    let amplify_crate = get_amplify_crate(&input);
+
+    let (field, _from) = get_params(&input)?;
+
+    let wrappers = get_wrappers::<WrapperMut>(&input)?;
+    let wrapper_derive = wrappers.iter().map(|w| w.into_token_stream2(&input));
+
+    Ok(quote! {
+        impl #impl_generics #amplify_crate::WrapperMut for #ident_name #ty_generics #where_clause {
+            #[inline]
+            fn as_inner_mut(&mut self) -> &mut <Self as #amplify_crate::Wrapper>::Inner {
+                &mut self.#field
+            }
+        }
+
+        impl #impl_generics ::core::convert::AsMut<<#ident_name #impl_generics as #amplify_crate::Wrapper>::Inner> for #ident_name #ty_generics #where_clause {
+            #[inline]
+            fn as_mut(&mut self) -> &mut <Self as #amplify_crate::Wrapper>::Inner {
+                use #amplify_crate::Wrapper;
+                WrapperMut::as_inner_mut(self)
+            }
+        }
+
+        impl #impl_generics ::core::borrow::BorrowMut<<#ident_name #impl_generics as #amplify_crate::Wrapper>::Inner> for #ident_name #ty_generics #where_clause {
+            #[inline]
+            fn borrow_mut(&mut self) -> &mut <Self as #amplify_crate::Wrapper>::Inner {
+                use #amplify_crate::Wrapper;
+                WrapperMut::as_inner_mut(self)
+            }
+        }
+
+        #( #wrapper_derive )*
+    })
+}
+
+fn get_params(input: &DeriveInput) -> Result<(TokenStream2, Type)> {
     let data = match input.data {
         Data::Struct(ref data) => data,
         Data::Enum(_) => {
@@ -596,33 +882,6 @@ pub(crate) fn inner(input: DeriveInput) -> Result<TokenStream2> {
             ))
         }
     };
-
-    let mut wrappers = vec![];
-    const WRAPPER_DERIVE_ERR: &str = "Wrapper attributes must be in a form of type list";
-    for attr in input
-        .attrs
-        .iter()
-        .filter(|attr| attr.path.is_ident("wrapper"))
-    {
-        match attr
-            .parse_meta()
-            .map_err(|_| attr_err!(attr, WRAPPER_DERIVE_ERR))?
-        {
-            Meta::List(MetaList { nested, .. }) => {
-                for meta in nested {
-                    match meta {
-                        NestedMeta::Meta(Meta::Path(path)) => {
-                            wrappers.push(WrapperDerives::from_path(&path)?.ok_or_else(|| {
-                                attr_err!(path, "Unrecognized wrapper parameter")
-                            })?);
-                        }
-                        _ => return Err(attr_err!(meta, WRAPPER_DERIVE_ERR)),
-                    }
-                }
-            }
-            _ => return Err(attr_err!(attr, WRAPPER_DERIVE_ERR)),
-        }
-    }
 
     let field;
     let mut from;
@@ -689,91 +948,35 @@ pub(crate) fn inner(input: DeriveInput) -> Result<TokenStream2> {
             ))
         }
     };
+    Ok((field, from))
+}
 
-    let wrapper_derive = wrappers.iter().map(|w| w.into_token_stream2(&input));
-
-    Ok(quote! {
-        impl #impl_generics #amplify_crate::Wrapper for #ident_name #ty_generics #where_clause {
-            type Inner = #from;
-
-            #[inline]
-            fn from_inner(inner: Self::Inner) -> Self {
-                Self::from(inner)
+fn get_wrappers<T: FromPath>(input: &DeriveInput) -> Result<Vec<T>> {
+    let mut wrappers = vec![];
+    const WRAPPER_DERIVE_ERR: &str = "Wrapper attributes must be in a form of type list";
+    for attr in input
+        .attrs
+        .iter()
+        .filter(|attr| attr.path.is_ident(T::IDENT))
+    {
+        match attr
+            .parse_meta()
+            .map_err(|_| attr_err!(attr, WRAPPER_DERIVE_ERR))?
+        {
+            Meta::List(MetaList { nested, .. }) => {
+                for meta in nested {
+                    match meta {
+                        NestedMeta::Meta(Meta::Path(path)) => {
+                            wrappers.push(T::from_path(&path)?.ok_or_else(|| {
+                                attr_err!(path, "Unrecognized wrapper parameter")
+                            })?);
+                        }
+                        _ => return Err(attr_err!(meta, WRAPPER_DERIVE_ERR)),
+                    }
+                }
             }
-
-            #[inline]
-            fn as_inner(&self) -> &Self::Inner {
-                &self.#field
-            }
-
-            #[inline]
-            fn as_inner_mut(&mut self) -> &mut Self::Inner {
-                &mut self.#field
-            }
-
-            #[inline]
-            fn into_inner(self) -> Self::Inner {
-                self.#field
-            }
+            _ => return Err(attr_err!(attr, WRAPPER_DERIVE_ERR)),
         }
-
-        impl #impl_generics ::core::convert::From<#ident_name #ty_generics> for #from #where_clause {
-            #[inline]
-            fn from(wrapped: #ident_name #ty_generics) -> Self {
-                use #amplify_crate::Wrapper;
-                Wrapper::into_inner(wrapped)
-            }
-        }
-
-        impl #impl_generics ::core::convert::AsRef<<#ident_name #impl_generics as #amplify_crate::Wrapper>::Inner> for #ident_name #ty_generics #where_clause {
-            #[inline]
-            fn as_ref(&self) -> &<Self as #amplify_crate::Wrapper>::Inner {
-                use #amplify_crate::Wrapper;
-                Wrapper::as_inner(self)
-            }
-        }
-
-        impl #impl_generics ::core::convert::AsMut<<#ident_name #impl_generics as #amplify_crate::Wrapper>::Inner> for #ident_name #ty_generics #where_clause {
-            #[inline]
-            fn as_mut(&mut self) -> &mut <Self as #amplify_crate::Wrapper>::Inner {
-                use #amplify_crate::Wrapper;
-                Wrapper::as_inner_mut(self)
-            }
-        }
-
-        impl #impl_generics ::core::borrow::Borrow<<#ident_name #impl_generics as #amplify_crate::Wrapper>::Inner> for #ident_name #ty_generics #where_clause {
-            #[inline]
-            fn borrow(&self) -> &<Self as #amplify_crate::Wrapper>::Inner {
-                use #amplify_crate::Wrapper;
-                Wrapper::as_inner(self)
-            }
-        }
-
-        impl #impl_generics ::core::borrow::BorrowMut<<#ident_name #impl_generics as #amplify_crate::Wrapper>::Inner> for #ident_name #ty_generics #where_clause {
-            #[inline]
-            fn borrow_mut(&mut self) -> &mut <Self as #amplify_crate::Wrapper>::Inner {
-                use #amplify_crate::Wrapper;
-                Wrapper::as_inner_mut(self)
-            }
-        }
-
-        impl #impl_generics ::core::ops::Deref for #ident_name #ty_generics #where_clause {
-            type Target = <Self as #amplify_crate::Wrapper>::Inner;
-            #[inline]
-            fn deref(&self) -> &Self::Target {
-                use #amplify_crate::Wrapper;
-                Wrapper::as_inner(self)
-            }
-        }
-
-        impl #impl_generics ::core::ops::DerefMut for #ident_name #ty_generics #where_clause {
-            #[inline]
-            fn deref_mut(&mut self) -> &mut Self::Target {
-                use #amplify_crate::Wrapper;
-                Wrapper::as_inner_mut(self)
-            }
-        }
-
-        #( #wrapper_derive )*
-    })
+    }
+    Ok(wrappers)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ pub mod num {
 pub use crate::as_any::AsAny;
 pub use crate::bipolar::Bipolar;
 pub use crate::strategy::Holder;
-pub use crate::wrapper::Wrapper;
+pub use crate::wrapper::{Wrapper, WrapperMut};
 pub use crate::slice32::Slice32;
 pub use crate::dumb_default::DumbDefault;
 #[cfg(feature = "serde")]

--- a/src/slice32.rs
+++ b/src/slice32.rs
@@ -25,6 +25,7 @@ use core::borrow::{Borrow, BorrowMut};
 #[cfg(all(feature = "hex", any(feature = "std", feature = "alloc")))]
 use crate::hex::{Error, FromHex, ToHex};
 use crate::Wrapper;
+use crate::wrapper::WrapperMut;
 
 /// Wrapper type for all slice-based 256-bit types implementing many important
 /// traits, so types based on it can simply derive their implementations.
@@ -177,13 +178,14 @@ impl Wrapper for Slice32 {
     }
 
     #[inline]
-    fn as_inner_mut(&mut self) -> &mut Self::Inner {
-        &mut self.0
-    }
-
-    #[inline]
     fn into_inner(self) -> Self::Inner {
         self.0
+    }
+}
+
+impl WrapperMut for Slice32 {
+    fn as_inner_mut(&mut self) -> &mut Self::Inner {
+        &mut self.0
     }
 }
 

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -55,7 +55,7 @@ pub trait Wrapper {
 }
 
 /// Trait allowing mutable reference borrowing for the wrapped inner type.
-pub trait WrapperMut {
+pub trait WrapperMut: Wrapper {
     /// Returns a mutable reference to the inner representation for the wrapper
     /// type
     fn as_inner_mut(&mut self) -> &mut Self::Inner;
@@ -79,12 +79,14 @@ mod test {
             &self.0
         }
 
-        fn as_inner_mut(&mut self) -> &mut Self::Inner {
-            &mut self.0
-        }
-
         fn into_inner(self) -> Self::Inner {
             self.0
+        }
+    }
+
+    impl WrapperMut for TestWrapper {
+        fn as_inner_mut(&mut self) -> &mut Self::Inner {
+            &mut self.0
         }
     }
 

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -32,10 +32,6 @@ pub trait Wrapper {
     /// Returns reference to the inner representation for the wrapper type
     fn as_inner(&self) -> &Self::Inner;
 
-    /// Returns a mutable reference to the inner representation for the wrapper
-    /// type
-    fn as_inner_mut(&mut self) -> &mut Self::Inner;
-
     /// Clones inner data of the wrapped type and return them
     #[inline]
     fn to_inner(&self) -> Self::Inner
@@ -56,6 +52,13 @@ pub trait Wrapper {
     {
         Self::from_inner(*self.as_inner())
     }
+}
+
+/// Trait allowing mutable reference borrowing for the wrapped inner type.
+pub trait WrapperMut {
+    /// Returns a mutable reference to the inner representation for the wrapper
+    /// type
+    fn as_inner_mut(&mut self) -> &mut Self::Inner;
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Tracking issue: #135 

- [x] Bump `amplify_derive` to new major version
- [x] Separate `Wrapper` and `WrapperMut` derives
- [x] Remove automatic deriving for `Deref` and `DerefMut`
- [x] Derive traits giving mutable access to the self only with `WrapperMut`