### PR TITLE
Refactor Holder pattern to avoid unnecessary clone

### DIFF
--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -93,7 +93,7 @@ impl<'a, T, S> Holder<'a, T, S> {
 
     #[allow(missing_docs)]
     #[inline]
-    pub fn unbox(self) -> &'a T {
+    pub fn unbox(&self) -> &'a T {
         self.0
     }
 }

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -50,19 +50,19 @@
 //! }
 //!
 //! // Do a single blanket implementation using Holder and Strategy marker trait
-//! impl<T> SampleTrait for T
+//! impl<'a, T> SampleTrait for &'a T
 //! where
-//!     T: Strategy + Clone,
-//!     amplify::Holder<T, <T as Strategy>::Strategy>: SampleTrait,
+//!     T: Strategy,
+//!     amplify::Holder<'a, T, <T as Strategy>::Strategy>: SampleTrait,
 //! {
 //!     // Do this for each of sample trait methods:
 //!     fn sample_trait_method(&self) {
-//!         amplify::Holder::new(self.clone()).sample_trait_method()
+//!         amplify::Holder::new(*self).sample_trait_method()
 //!     }
 //! }
 //!
 //! // Do this type of implementation for each of the strategies
-//! impl<T> SampleTrait for amplify::Holder<T, StrategyA>
+//! impl<'a, T> SampleTrait for amplify::Holder<'a, T, StrategyA>
 //! where
 //!     T: Strategy,
 //! {
@@ -83,23 +83,17 @@ use ::core::marker::PhantomData;
 
 /// Helper type allowing implementation of trait object for generic types
 /// multiple times. In practice this type is never used
-pub struct Holder<T, S>(T, PhantomData<S>);
-impl<T, S> Holder<T, S> {
+pub struct Holder<'a, T, S>(&'a T, PhantomData<S>);
+impl<'a, T, S> Holder<'a, T, S> {
     #[allow(missing_docs)]
     #[inline]
-    pub fn new(val: T) -> Self {
+    pub fn new(val: &'a T) -> Self {
         Self(val, PhantomData::<S>::default())
     }
 
     #[allow(missing_docs)]
     #[inline]
-    pub fn into_inner(self) -> T {
+    pub fn unbox(self) -> &'a T {
         self.0
-    }
-
-    #[allow(missing_docs)]
-    #[inline]
-    pub fn as_inner(&self) -> &T {
-        &self.0
     }
 }

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -52,22 +52,23 @@
 //! // Do a single blanket implementation using Holder and Strategy marker trait
 //! impl<T> SampleTrait for T
 //! where
-//!     T: Strategy + Clone,
-//!     amplify::Holder<T, <T as Strategy>::Strategy>: SampleTrait,
+//!     T: Strategy,
+//!     for<'a> amplify::Holder<&'a T, T::Strategy>: SampleTrait,
 //! {
 //!     // Do this for each of sample trait methods:
 //!     fn sample_trait_method(&self) {
-//!         amplify::Holder::new(self.clone()).sample_trait_method()
+//!         amplify::Holder::new(self).sample_trait_method()
 //!     }
 //! }
 //!
 //! // Do this type of implementation for each of the strategies
-//! impl<T> SampleTrait for amplify::Holder<T, StrategyA>
+//! impl<'a, T> SampleTrait for amplify::Holder<&'a T, StrategyA>
 //! where
 //!     T: Strategy,
 //! {
 //!     fn sample_trait_method(&self) {
-//!         /* ... write your implementation-specific code here */
+//!         /* write your implementation-specific code here accessing type data,
+//!            when needed, via `self.as_inner()` */
 //!     }
 //! }
 //!
@@ -85,13 +86,13 @@ use ::core::marker::PhantomData;
 /// multiple times. In practice this type is never used
 pub struct Holder<T, S>(T, PhantomData<S>);
 impl<T, S> Holder<T, S> {
-    #[allow(missing_docs)]
+    /// Wraps type into a holder to apply necessary blanked implementations.
     #[inline]
     pub fn new(val: T) -> Self {
         Self(val, PhantomData::<S>::default())
     }
 
-    #[allow(missing_docs)]
+    /// Returns a reference to the wrapped type.
     #[inline]
     pub fn as_type(&self) -> &T {
         &self.0

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -50,19 +50,19 @@
 //! }
 //!
 //! // Do a single blanket implementation using Holder and Strategy marker trait
-//! impl<'a, T> SampleTrait for &'a T
+//! impl<T> SampleTrait for T
 //! where
-//!     T: Strategy,
-//!     amplify::Holder<'a, T, <T as Strategy>::Strategy>: SampleTrait,
+//!     T: Strategy + Clone,
+//!     amplify::Holder<T, <T as Strategy>::Strategy>: SampleTrait,
 //! {
 //!     // Do this for each of sample trait methods:
 //!     fn sample_trait_method(&self) {
-//!         amplify::Holder::new(*self).sample_trait_method()
+//!         amplify::Holder::new(self.clone()).sample_trait_method()
 //!     }
 //! }
 //!
 //! // Do this type of implementation for each of the strategies
-//! impl<'a, T> SampleTrait for amplify::Holder<'a, T, StrategyA>
+//! impl<T> SampleTrait for amplify::Holder<T, StrategyA>
 //! where
 //!     T: Strategy,
 //! {
@@ -83,17 +83,17 @@ use ::core::marker::PhantomData;
 
 /// Helper type allowing implementation of trait object for generic types
 /// multiple times. In practice this type is never used
-pub struct Holder<'a, T, S>(&'a T, PhantomData<S>);
-impl<'a, T, S> Holder<'a, T, S> {
+pub struct Holder<T, S>(T, PhantomData<S>);
+impl<T, S> Holder<T, S> {
     #[allow(missing_docs)]
     #[inline]
-    pub fn new(val: &'a T) -> Self {
+    pub fn new(val: T) -> Self {
         Self(val, PhantomData::<S>::default())
     }
 
     #[allow(missing_docs)]
     #[inline]
-    pub fn unbox(&self) -> &'a T {
-        self.0
+    pub fn as_type(&self) -> &T {
+        &self.0
     }
 }


### PR DESCRIPTION
This has one aggravation though: downstream you can't now have ability to call `Trait` on type `T`, only on `&T`. I.e. if you have a trait called `trait DoSomething { do_something(&self) }` and you have `impl do_something::Strategy for SomeType { type Strategy = SomeShit }`, you have to call it as `let shit = SomeType::new(); (&shit).do_something();`