### PR TITLE
Release v4.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 Change Log
 ==========
 
+4.0.2
+-----
+
+- fix for Array serde encoding to support non-standard hex implementations 
+  on top
+- update dependencies
+- pin dependencies to maintain MSRV
+
+4.0.1
+-----
+
+- fix FromHex Array implementation bug
+
 3.14.0
 ------
 - New collection confinement module

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "amplify"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "amplify_apfloat",
  "amplify_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amplify"
-version = "4.0.1"
+version = "4.0.2"
 description = "Amplifying Rust language capabilities: multiple generic trait implementations, type wrappers, derive macros"
 authors = [
     "Dr. Maxim Orlovsky <orlovsky@pandoracore.com>",


### PR DESCRIPTION
- fix for Array serde encoding to support non-standard hex implementations on top
- update dependencies
- pin dependencies to maintain MSRV
