### PR TITLE
Release 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 Change Log
 ==========
 
+4.1.0
+-----
+- add generic parameter to Array to support reverse string representation
+- add Bytes, Bytes4, Bytes20 and Bytes32StrRev type aliases
+- add support for no-std to confined collections
+
 4.0.2
 -----
-
 - fix for Array serde encoding to support non-standard hex implementations 
   on top
 - update dependencies
@@ -11,7 +16,6 @@ Change Log
 
 4.0.1
 -----
-
 - fix FromHex Array implementation bug
 
 3.14.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "amplify"
-version = "4.0.2"
+version = "4.1.0"
 dependencies = [
  "amplify_apfloat",
  "amplify_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amplify"
-version = "4.0.2"
+version = "4.1.0"
 description = "Amplifying Rust language capabilities: multiple generic trait implementations, type wrappers, derive macros"
 authors = [
     "Dr. Maxim Orlovsky <orlovsky@pandoracore.com>",


### PR DESCRIPTION
- add generic parameter to Array to support reverse string representation
- add Bytes, Bytes4, Bytes20 and Bytes32StrRev type aliases
- add support for no-std to confined collections
