### PR TITLE
fix alloc/std features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ libc = { version = "0.2", optional = true }
 amplify_derive = { version = "4.0.1", optional = true }
 amplify_syn = { version = "2.0.1", optional = true }
 amplify_num = { version = "0.5.3" }
-amplify_apfloat = { version = "0.3.1", optional = true }
-ascii = "1.1.0"
+amplify_apfloat = { version = "0.3.1", default-features = false, optional = true }
+ascii = { version = "1.1.0", default-features = false }
 rand = { version = "0.8.5", optional = true }
 # This strange naming is a workaround for not being able to define required features for a dependency
 # See https://github.com/rust-lang/api-guidelines/issues/180 for the explanation and references.
@@ -60,9 +60,9 @@ all = [
     "apfloat_std",
 ]
 default = ["std", "derive", "hex"]
-std = ["amplify_num/std", "alloc"]
+std = ["amplify_num/std", "ascii/std"]
 apfloat_std = ["amplify_apfloat/std"]
-alloc = ["amplify_num/alloc"]
+alloc = ["amplify_num/alloc", "ascii/alloc"]
 apfloat_alloc = ["amplify_apfloat/alloc"]
 c_raw = ["libc", "std"]
 hex = ["amplify_num/hex"]
@@ -78,3 +78,6 @@ serde = [
     "stringly_conversions/alloc",
     "stringly_conversions/serde_str_helpers",
 ]
+
+[patch.crates-io]
+amplify_derive = { git = "https://github.com/zoedberg/amplify-derive", branch = "minor_fixes" }

--- a/src/collection/array.rs
+++ b/src/collection/array.rs
@@ -13,9 +13,10 @@
 // along with this software.
 // If not, see <https://opensource.org/licenses/MIT>.
 
+#[cfg(feature = "std")]
+use std::vec::Vec;
 #[cfg(all(feature = "hex", any(feature = "std", feature = "alloc")))]
 use core::fmt::{LowerHex, UpperHex};
-#[cfg(any(feature = "std", feature = "alloc"))]
 use core::fmt::{self, Display, Debug, Formatter};
 #[cfg(all(feature = "hex", any(feature = "std", feature = "alloc")))]
 use core::str::FromStr;

--- a/src/collection/confinement.rs
+++ b/src/collection/confinement.rs
@@ -22,16 +22,23 @@ use core::hash::Hash;
 use core::ops::{
     Deref, Index, IndexMut, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive,
 };
-use alloc::vec::Vec;
-use alloc::string::String;
-use alloc::borrow::ToOwned;
-use alloc::collections::{btree_map, BTreeMap, BTreeSet, VecDeque};
-use core::slice::SliceIndex;
+#[cfg(feature = "alloc")]
+use alloc::{
+    vec::Vec,
+    string::String,
+    borrow::ToOwned,
+    collections::{btree_map, BTreeMap, BTreeSet, VecDeque},
+};
 #[cfg(feature = "std")]
 use std::{
+    vec::Vec,
+    string::String,
+    borrow::ToOwned,
+    collections::{btree_map, BTreeMap, BTreeSet, VecDeque},
     io,
     collections::{hash_map, HashMap, HashSet},
 };
+use core::slice::SliceIndex;
 use amplify_num::hex;
 use amplify_num::hex::{FromHex, ToHex};
 use ascii::{AsAsciiStrError, AsciiChar, AsciiString};

--- a/src/collection/flags.rs
+++ b/src/collection/flags.rs
@@ -21,6 +21,8 @@ use std::fmt::{self, Binary, Debug, Display, Formatter, LowerHex, Octal, UpperHe
 use std::hash::{Hash, Hasher};
 use std::ops::{BitAnd, BitOr, BitXor};
 use std::str::FromStr;
+use std::vec;
+use std::vec::Vec;
 
 use crate::confinement::TinyVec;
 

--- a/src/collection/mod.rs
+++ b/src/collection/mod.rs
@@ -13,7 +13,6 @@
 // along with this software.
 // If not, see <https://opensource.org/licenses/MIT>.
 
-#[cfg(feature = "alloc")]
 #[macro_use]
 pub mod confinement;
 mod array;

--- a/src/io_util.rs
+++ b/src/io_util.rs
@@ -14,11 +14,14 @@
 // along with this software.
 // If not, see <https://opensource.org/licenses/MIT>.
 
+use std::boxed::Box;
 use std::cmp::Ordering;
 use std::io;
+use std::format;
 use std::fmt::{Debug, Display, Formatter, self};
 use std::error::Error as StdError;
 use std::hash::{Hash, Hasher};
+use std::string::{String, ToString};
 
 /// A simple way to count bytes written through [`io::Write`].
 #[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Default, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,12 +17,22 @@
 //! Amplifying Rust language capabilities: multiple generic trait
 //! implementations, type wrappers, derive macros.
 //!
-//! Minimum supported rust compiler version (MSRV): 1.46 (stable channel)
+//! Minimum supported rust compiler version (MSRV): 1.75 (stable channel)
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
+
+#[cfg(feature = "std")]
+extern crate std;
 
 #[cfg(feature = "alloc")]
-pub extern crate alloc;
+extern crate alloc;
+
+#[cfg(not(any(feature = "std", feature = "alloc")))]
+compile_error!("Either `std` or `alloc` feature must be enabled.");
+
+#[cfg(all(feature = "std", feature = "alloc"))]
+compile_error!("Both `std` and `alloc` features cannot be enabled at the same time.");
+
 extern crate core;
 
 #[cfg(feature = "derive")]
@@ -55,7 +65,7 @@ mod macro_default;
 #[cfg(feature = "std")]
 #[macro_use]
 mod macro_std;
-#[cfg(all(feature = "alloc", not(feature = "std")))]
+#[cfg(feature = "alloc")]
 #[macro_use]
 mod macro_alloc;
 

--- a/src/traits/as_any.rs
+++ b/src/traits/as_any.rs
@@ -13,6 +13,8 @@
 // along with this software.
 // If not, see <https://opensource.org/licenses/MIT>.
 
+#[cfg(feature = "std")]
+use std::string::String;
 use core::any::Any;
 #[cfg(feature = "alloc")]
 use alloc::string::String;


### PR DESCRIPTION
While trying to fix the build of rust-aluvm with only the `alloc` feature (`cargo check --workspace --no-default-features --features alloc`) I've noticed there's quite a mess regarding `std` and `alloc` features. For example there are crates like baid64 that are not defining these features (therefore forcing their dependents to import `std`) or amplify that exports the `confinement` module only if `alloc` is activated (causing builds with only `std` to fail). 

This PR fixes imports of `std` and `alloc` features in a way that now amplify doesn't import `std` if we specify `--no-default-features --features alloc` and viceversa.

This change though:
```diff
- #[cfg(feature = "std")]
+ #[cfg(all(feature = "std", not(feature = "alloc")))]
```
can work only if the `std` and `alloc` are mutually exclusive and if dependencies that use the `alloc` feature do not have other dependencies importing amplify with the `std` feature. 

I can fix these issues but first I need to understand what's the desired result. My proposal is to make all dependencies have `std` and `alloc` features, make them exclusive and to expose everything in both `std` and `alloc` version, @dr-orlovsky let me know your thoughts about this

